### PR TITLE
Update data schema

### DIFF
--- a/src/db/model.py
+++ b/src/db/model.py
@@ -55,7 +55,6 @@ class Pack(Base, SimplePrinterBase):
     id = Column(Integer, primary_key=True)
     draft = Column(Integer, ForeignKey('drafts.id'), nullable=False)
     pick_number = Column(Integer, nullable=False)
-    expansion = Column(String(3), ForeignKey('expansions.abbreviation'), nullable=False)
 
 class PackCard(Base, SimplePrinterBase):
     __tablename__ = 'pack_cards'

--- a/src/db/model.py
+++ b/src/db/model.py
@@ -45,22 +45,15 @@ class Draft(Base, SimplePrinterBase):
     __tablename__ = 'drafts'
 
     id = Column(Integer, primary_key=True)
+    user = Column(Integer, ForeignKey('users.id'), nullable=False)
     name = Column(String(255), nullable=False)
     start_time = Column(DateTime, nullable=True)
-
-class DraftSeat(Base, SimplePrinterBase):
-    __tablename__ = 'draft_seats'
-
-    id = Column(Integer, primary_key=True)
-    draft = Column(Integer, ForeignKey('drafts.id'), nullable=False)
-    user = Column(Integer, ForeignKey('users.id'), nullable=False)
-    seat_number = Column(Integer, nullable=True)
 
 class Pack(Base, SimplePrinterBase):
     __tablename__ = 'packs'
 
     id = Column(Integer, primary_key=True)
-    draft_seat = Column(Integer, ForeignKey('draft_seats.id'), nullable=False)
+    draft = Column(Integer, ForeignKey('drafts.id'), nullable=False)
     pick_number = Column(Integer, nullable=False)
     expansion = Column(String(3), ForeignKey('expansions.abbreviation'), nullable=False)
 

--- a/src/db/model.py
+++ b/src/db/model.py
@@ -23,6 +23,7 @@ class Card(Base, SimplePrinterBase):
     __tablename__ = 'cards'
 
     id = Column(Integer, primary_key=True)
+    multiverse_id = Column(Integer, nullable=False)
     expansion = Column(Integer, ForeignKey('expansions.id'), nullable=False)
     name = Column(String(255), nullable=False)
     rarity = Column(String(255), nullable=False)
@@ -69,12 +70,10 @@ class PackCard(Base, SimplePrinterBase):
 
     id = Column(Integer, primary_key=True)
     pack = Column(Integer, ForeignKey('packs.id'), nullable=False)
-    card = Column(Integer, ForeignKey('cards.id'), nullable=False)
+    card_multiverse_id = Column(Integer, nullable=False)
 
 class Pick(Base, SimplePrinterBase):
     __tablename__ = 'picks'
 
     id = Column(Integer, primary_key=True)
-    user = Column(Integer, ForeignKey('users.id'), nullable=False)
-    pick_number = Column(Integer, nullable=False)
     pack_card = Column(Integer, ForeignKey('pack_cards.id'), nullable=False)

--- a/src/db/model.py
+++ b/src/db/model.py
@@ -14,8 +14,7 @@ class SimplePrinterBase(object):
 class Expansion(Base, SimplePrinterBase):
     __tablename__ = 'expansions'
 
-    id = Column(Integer, primary_key=True)
-    abbreviation = Column(String(255), nullable=False)
+    abbreviation = Column(String(3), nullable=False, primary_key=True)
     name = Column(String(255), nullable=False)
     max_booster_number = Column(Integer, nullable=False)
 
@@ -24,7 +23,7 @@ class Card(Base, SimplePrinterBase):
 
     id = Column(Integer, primary_key=True)
     multiverse_id = Column(Integer, nullable=False)
-    expansion = Column(Integer, ForeignKey('expansions.id'), nullable=False)
+    expansion = Column(String(3), ForeignKey('expansions.abbreviation'), nullable=False)
     name = Column(String(255), nullable=False)
     rarity = Column(String(255), nullable=False)
     number = Column(Integer, nullable=False)
@@ -63,7 +62,7 @@ class Pack(Base, SimplePrinterBase):
     id = Column(Integer, primary_key=True)
     draft_seat = Column(Integer, ForeignKey('draft_seats.id'), nullable=False)
     pick_number = Column(Integer, nullable=False)
-    expansion = Column(Integer, ForeignKey('expansions.id'), nullable=False)
+    expansion = Column(String(3), ForeignKey('expansions.abbreviation'), nullable=False)
 
 class PackCard(Base, SimplePrinterBase):
     __tablename__ = 'pack_cards'

--- a/src/importer/log_importer.py
+++ b/src/importer/log_importer.py
@@ -134,7 +134,7 @@ def get_or_add_user(session, username):
     return user
 
 def add_pack(session, seat, expansion, pick_number, pack_card_names, pick):
-    pack = Pack(draft_seat=seat.id, pick_number=pick_number, expansion=expansion.id)
+    pack = Pack(draft_seat=seat.id, pick_number=pick_number, expansion=expansion.abbreviation)
     session.add(pack)
 
     picked = False
@@ -156,12 +156,12 @@ def query_card(session, expansion, card_name):
 
     card_name = card_name.strip()
 
-    result = session.query(Card).filter_by(expansion=expansion.id, name=card_name).scalar()
+    result = session.query(Card).filter_by(expansion=expansion.abbreviation, name=card_name).scalar()
     if result:
         return result
 
     for suffix in SUFFIXES_TO_STRIP:
-        result = session.query(Card).filter_by(expansion=expansion.id, name=f'{card_name}{suffix}').scalar()
+        result = session.query(Card).filter_by(expansion=expansion.abbreviation, name=f'{card_name}{suffix}').scalar()
         if result:
             return result
 

--- a/src/importer/log_importer.py
+++ b/src/importer/log_importer.py
@@ -131,7 +131,7 @@ def get_or_add_user(session, username):
     return user
 
 def add_pack(session, draft, expansion, pick_number, pack_card_names, pick):
-    pack = Pack(draft=draft.id, pick_number=pick_number, expansion=expansion.abbreviation)
+    pack = Pack(draft=draft.id, pick_number=pick_number)
     session.add(pack)
 
     picked = False

--- a/src/importer/log_importer.py
+++ b/src/importer/log_importer.py
@@ -94,7 +94,7 @@ def get_next_pack_cards(file):
         if match:
             pack_number = int(match.group(1))
             pick_in_pack = int(match.group(2))
-            pick_number = pack_number * CARDS_IN_PACK + pick_in_pack
+            pick_number = (pack_number - 1) * CARDS_IN_PACK + pick_in_pack
             break
 
     pack_card_names = []

--- a/src/importer/log_importer.py
+++ b/src/importer/log_importer.py
@@ -140,12 +140,12 @@ def add_pack(session, seat, expansion, pick_number, pack_card_names, pick):
     picked = False
     for card_name in pack_card_names:
         card = query_card(session, expansion, card_name)
-        pack_card = PackCard(pack=pack.id, card=card.id)
+        pack_card = PackCard(pack=pack.id, card_multiverse_id=card.multiverse_id)
         session.add(pack_card)
 
         if card_name == pick and not picked:
             session.flush()
-            session.add(Pick(user=seat.user, pick_number=pick_number, pack_card=pack_card.id))
+            session.add(Pick(pack_card=pack_card.id))
             picked = True
 
     assert picked, 'No cards were picked'

--- a/src/importer/set_importer.py
+++ b/src/importer/set_importer.py
@@ -76,7 +76,7 @@ def add_from_json(session, blob):
     expansion = get_or_persist_expansion(session, convert_blob_to_expansion(blob))
     session.flush()
     for cardBlob in blob['cards']:
-        get_or_persist_card(session, convert_blob_to_card(cardBlob, expansion.id))
+        get_or_persist_card(session, convert_blob_to_card(cardBlob, expansion.abbreviation))
     session.commit()
 
 if __name__ == '__main__':

--- a/src/importer/set_importer.py
+++ b/src/importer/set_importer.py
@@ -38,6 +38,7 @@ def convert_blob_to_card(blob, expansion_id):
     face = None if parsed_number.group(2) == '' else parsed_number.group(2)
 
     c = Card(
+        multiverse_id=blob['multiverseid'],
         expansion=expansion_id,
         name=name,
         number=number,

--- a/test/importer/test_set_importer.py
+++ b/test/importer/test_set_importer.py
@@ -51,6 +51,7 @@ def test_convert_blob_to_card_basic_creatures():
     blob = {
         "manaCost": "{2}{R}",
         "name": "Fearless Halberdier",
+        "multiverseid": 452850,
         "number": "100",
         "power": "3",
         "rarity": "Common",
@@ -60,6 +61,7 @@ def test_convert_blob_to_card_basic_creatures():
 
     actual = importer.set_importer.convert_blob_to_card(blob, expansion_id=123)
 
+    assert 452850 == actual.multiverse_id
     assert 123 == actual.expansion
     assert 'Fearless Halberdier' == actual.name
     assert 'Common' == actual.rarity
@@ -107,6 +109,7 @@ def test_convert_blob_to_card_variable_power_creatures():
 
     actual = importer.set_importer.convert_blob_to_card(blob, expansion_id=123)
 
+    assert 452913 == actual.multiverse_id
     assert 123 == actual.expansion
     assert 'Crackling Drake' == actual.name
     assert 'Uncommon' == actual.rarity
@@ -121,6 +124,7 @@ def test_convert_blob_to_card_variable_power_creatures():
 
 def test_convert_blob_to_card_planeswalkers():
     blob = {
+        "multiverseid": 452945,
         "loyalty": 5,
         "manaCost": "{3}{U}{R}",
         "name": "Ral, Izzet Viceroy",
@@ -132,6 +136,7 @@ def test_convert_blob_to_card_planeswalkers():
 
     actual = importer.set_importer.convert_blob_to_card(blob, expansion_id=321)
 
+    assert 452945 == actual.multiverse_id
     assert 321 == actual.expansion
     assert 'Ral, Izzet Viceroy' == actual.name
     assert 'Mythic Rare' == actual.rarity

--- a/test/importer/test_set_importer.py
+++ b/test/importer/test_set_importer.py
@@ -59,10 +59,10 @@ def test_convert_blob_to_card_basic_creatures():
         "type": "Creature — Human Warrior",
     }
 
-    actual = importer.set_importer.convert_blob_to_card(blob, expansion_id=123)
+    actual = importer.set_importer.convert_blob_to_card(blob, expansion_id='GRN')
 
     assert 452850 == actual.multiverse_id
-    assert 123 == actual.expansion
+    assert 'GRN' == actual.expansion
     assert 'Fearless Halberdier' == actual.name
     assert 'Common' == actual.rarity
     assert 100 == actual.number
@@ -107,10 +107,10 @@ def test_convert_blob_to_card_variable_power_creatures():
         "watermark": "Izzet"
     }
 
-    actual = importer.set_importer.convert_blob_to_card(blob, expansion_id=123)
+    actual = importer.set_importer.convert_blob_to_card(blob, expansion_id='GRN')
 
     assert 452913 == actual.multiverse_id
-    assert 123 == actual.expansion
+    assert 'GRN' == actual.expansion
     assert 'Crackling Drake' == actual.name
     assert 'Uncommon' == actual.rarity
     assert 163 == actual.number
@@ -134,10 +134,10 @@ def test_convert_blob_to_card_planeswalkers():
         "type": "Legendary Planeswalker — Ral",
     }
 
-    actual = importer.set_importer.convert_blob_to_card(blob, expansion_id=321)
+    actual = importer.set_importer.convert_blob_to_card(blob, expansion_id='GRN')
 
     assert 452945 == actual.multiverse_id
-    assert 321 == actual.expansion
+    assert 'GRN' == actual.expansion
     assert 'Ral, Izzet Viceroy' == actual.name
     assert 'Mythic Rare' == actual.rarity
     assert 195 == actual.number
@@ -151,9 +151,9 @@ def test_convert_blob_to_card_planeswalkers():
 
 def test_get_or_persist_expansion_existing_expansion(mocker):
     get_expansion = mocker.patch('db.expansion_repository.get_expansion')
-    get_expansion.return_value = Expansion(id=123)
+    get_expansion.return_value = Expansion(abbreviation='ABC')
 
-    assert 123 == importer.set_importer.get_or_persist_expansion('my-session', Expansion(name='my-expansion')).id
+    assert 'ABC' == importer.set_importer.get_or_persist_expansion('my-session', Expansion(name='my-expansion')).abbreviation
     db.expansion_repository.get_expansion.assert_called_once_with('my-session', 'my-expansion')
 
 def test_get_or_persist_expansion_new_expansion(mocker):
@@ -171,16 +171,16 @@ def test_get_or_persist_card_existing_card(mocker):
     get_card = mocker.patch('db.card_repository.get_card')
     get_card.return_value = Card(id=123)
 
-    assert 123 == importer.set_importer.get_or_persist_card('my-session', Card(expansion=42, number=100, face='A')).id
-    db.card_repository.get_card.assert_called_once_with(session='my-session', expansion_id=42, number=100, face='A')
+    assert 123 == importer.set_importer.get_or_persist_card('my-session', Card(expansion='ABC', number=100, face='A')).id
+    db.card_repository.get_card.assert_called_once_with(session='my-session', expansion_id='ABC', number=100, face='A')
 
 def test_get_or_persist_card_new_card(mocker):
     get_card = mocker.patch('db.card_repository.get_card')
     get_card.return_value = None
 
     mock_session = MagicMock()
-    input_card = Card(expansion=42, number=100, face='A')
+    input_card = Card(expansion='ABC', number=100, face='A')
 
     assert input_card == importer.set_importer.get_or_persist_card(mock_session, input_card)
-    db.card_repository.get_card.assert_called_once_with(session=mock_session, expansion_id=42, number=100, face='A')
+    db.card_repository.get_card.assert_called_once_with(session=mock_session, expansion_id='ABC', number=100, face='A')
     mock_session.add.assert_called_once_with(input_card)


### PR DESCRIPTION
* Uses abbreviation (e.g. 'GRN') as the identifier for sets
* Adds multiverse_id as a field to cards (note that this is not unique, e.g. 'Invert' and 'Invent' have the same multiverse_id)
* Removes a couple of redundant fields from the `Pick` object

Relates to #1 